### PR TITLE
avoid display in sitemap unpublished pages

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -67,7 +67,7 @@ class SitemapPlugin extends Plugin
         foreach ($routes as $route => $path) {
             $page = $pages->get($path);
 
-            if ($page->routable() && !in_array($page->route(), $ignores)) {
+            if ($page->published() && $page->routable() && !in_array($page->route(), $ignores)) {
                 $entry = new SitemapEntry();
                 $entry->location = $page->permaLink();
                 $entry->lastmod = date('Y-m-d', $page->modified());


### PR DESCRIPTION
At the moment, sitemap plugin adds unpublished pages to sitemap: this PR fixes this bug.