### PR TITLE
Escape the loc so it is properly parsed.

### DIFF
--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for entry in sitemap %}
     <url>
-        <loc>{{ entry.location }}</loc>
+        <loc>{{ entry.location|e }}</loc>
         <lastmod>{{ entry.lastmod }}</lastmod>
         {% if entry.changefreq %}
         <changefreq>{{ entry.changefreq }}</changefreq>


### PR DESCRIPTION
Not escaping the entry.location value will make urls containing "&" break.

ex. kemp-&-tenenbaum-the-discovery-of-structural-form