### PR TITLE
Added ability to add non-grav URL to sitemap

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -81,6 +81,17 @@ class SitemapPlugin extends Plugin
                 $this->sitemap[$route] = $entry;
             }
         }
+
+        $rootUrl = $this->grav['uri']->rootUrl(true) . $pages->base();
+        $additions = (array) $this->config->get('plugins.sitemap.additions');
+
+        foreach ($additions as $addition) {
+            $entry = new SitemapEntry();
+            $entry->location = $rootUrl . $addition['location'];
+            $entry->lastmod = $addition['lastmod'];
+
+            $this->sitemap[] = $entry;
+        }
     }
 
     public function onPageInitialized()

--- a/sitemap.yaml
+++ b/sitemap.yaml
@@ -5,3 +5,7 @@ priority: !!float 1
 ignores:
   - /blog/blog-post-to-ignore
   - /ignore-this-route
+additions:
+  -
+    location: /not-a-grav-url
+    lastmod: '2017-04-06'


### PR DESCRIPTION
I use Grav on a main domain which have 2 or 3 "non grav" URL which are important.

I needed the possibility to add those URL into the sitemap.