### PR TITLE
page-level sitemap ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ route: '/sitemap'
 ignores:
   - /blog/blog-post-to-ignore
   - /ignore-this-route
+  - /ignore-children-of-this-route/.*
 ```
 
 You can ignore your own pages by providing a list of routes to ignore.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ ignores:
   - /ignore-children-of-this-route/.*
 ```
 
-You can ignore your own pages by providing a list of routes to ignore.
+You can ignore your own pages by providing a list of routes to ignore. You can also use a page's Frontmatter to signal that the sitemap should ignore it:
+
+```
+sitemap:
+    ignore: true
+```
 
 ## Only allow access to the .xml file
 

--- a/sitemap.php
+++ b/sitemap.php
@@ -68,7 +68,7 @@ class SitemapPlugin extends Plugin
         foreach ($routes as $route => $path) {
             $page = $pages->get($path);
 
-            if ($page->published() && $page->routable() && !in_array($page->route(), $ignores)) {
+            if ($page->published() && $page->routable() && !preg_match(sprintf("@^(%s)$@i", implode('|', $ignores)), $page->route())) {
                 $entry = new SitemapEntry();
                 $entry->location = $page->canonical();
                 $entry->lastmod = date('Y-m-d', $page->modified());

--- a/sitemap.php
+++ b/sitemap.php
@@ -67,14 +67,15 @@ class SitemapPlugin extends Plugin
 
         foreach ($routes as $route => $path) {
             $page = $pages->get($path);
+            $header = $page->header();
+            $page_ignored = isset($header->sitemap['ignore']) ? $header->sitemap['ignore'] : false;
 
-            if ($page->published() && $page->routable() && !preg_match(sprintf("@^(%s)$@i", implode('|', $ignores)), $page->route())) {
+            if ($page->published() && $page->routable() && !preg_match(sprintf("@^(%s)$@i", implode('|', $ignores)), $page->route()) && !$page_ignored) {
                 $entry = new SitemapEntry();
                 $entry->location = $page->canonical();
                 $entry->lastmod = date('Y-m-d', $page->modified());
 
                 // optional changefreq & priority that you can set in the page header
-                $header = $page->header();
                 $entry->changefreq = (isset($header->sitemap['changefreq'])) ? $header->sitemap['changefreq'] : $this->config->get('plugins.sitemap.changefreq');
                 $entry->priority = (isset($header->sitemap['priority'])) ? $header->sitemap['priority'] : $this->config->get('plugins.sitemap.priority');
 

--- a/sitemap.yaml
+++ b/sitemap.yaml
@@ -5,3 +5,4 @@ priority: !!float 1
 ignores:
   - /blog/blog-post-to-ignore
   - /ignore-this-route
+  - /ignore-children-of-this-route/.*


### PR DESCRIPTION
Adding the ability to flag a page to be ignored by the sitemap within the page's Frontmatter. This is just an additional way to ignore a page which other folks may find useful. I could also see this being used down the line to show a page which is being ignored by a wildcard (i.e. if I'm ignoring "/path/.*" but I would like to not ignore "/path/unique-page" by setting ignore to false). This would require some further tweaking though.