### PR TITLE
Add a namespace xhtml for a international sitemap

### DIFF
--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="{{ uri.rootUrl }}/user/plugins/sitemap/sitemap.xsl"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 {% for entry in sitemap %}
   <url>
     <loc>{{ entry.location|e }}</loc>


### PR DESCRIPTION
Firefox has a error to read my sitemap and Google search console indicated that it was missing this line.