### PR TITLE
Global toggles for change frequency and priority

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -27,6 +27,39 @@ form:
         0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
+  
+    changefreq:
+      type: select
+      label: Global - sitemap change frequency
+      default: ''
+      options:
+        '': Use Global (daily)
+        always: Always
+        hourly: Hourly
+        daily: Daily
+        weekly: Weekly
+        monthly: Monthly
+        yearly: Yearly
+        never:  Never
+        
+    priority:
+      type: select
+      label: Global - sitemap priority
+      default: ''
+      options:
+        '': Use Global (1)
+        '0.1': 0.1
+        '0.2': 0.2
+        '0.3': 0.3
+        '0.4': 0.4
+        '0.5': 0.5
+        '0.6': 0.6
+        '0.7': 0.7
+        '0.8': 0.8
+        '0.9': 0.9
+        '1.0': 1.0
+      validate:
+        type: float
 
     route:
       type: text


### PR DESCRIPTION
I see these two fields (changefreq and priority) have global defaults in sitemap.yaml but I didn't see anyway to set these globals via the admin panel.

I thought adding these two fields was a "nice to have" rather than a feature because the sitemap fields on pages in the admin panel all say "Use Global" I thought it would be useful to be able to set the globals from within the admin panel. However I don't think Google has used these fields for years so not really a priority. 