### PR TITLE
#51 Make sure the sitemap blueprints are only getting included to non-modular pages

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -148,11 +148,13 @@ class SitemapPlugin extends Plugin
         /** @var Data\Blueprint $blueprint */
         $blueprint = $event['blueprint'];
         if (!$inEvent && $blueprint->get('form/fields/tabs', null, '/')) {
-            $inEvent = true;
-            $blueprints = new Data\Blueprints(__DIR__ . '/blueprints/');
-            $extends = $blueprints->get('sitemap');
-            $blueprint->extend($extends, true);
-            $inEvent = false;
+            if (!in_array($blueprint->getFilename(), array_keys($this->grav['pages']->modularTypes()))) {
+                $inEvent = true;
+                $blueprints = new Data\Blueprints(__DIR__ . '/blueprints/');
+                $extends = $blueprints->get('sitemap');
+                $blueprint->extend($extends, true);
+                $inEvent = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Since non-modular items don't get listed in the sitemap, it's not necessary to show the blueprint config to the module options. This is very confusing for content editors.

Similar issue https://github.com/getgrav/grav-plugin-sitemap/issues/51