### PR TITLE
Remove / from end of the home urls

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -85,7 +85,7 @@ class SitemapPlugin extends Plugin
                     foreach($entry->translated as $lang => $page_route) {
                         $page_route = $page->rawRoute();
                         if ($page->home()) {
-                            $page_route = '/';
+                            $page_route = '';
                         }
 
                         $entry->translated[$lang] = $page_route;


### PR DESCRIPTION
This unnecessary / at the end of home page urls causes an unhelpful redirect which can confuse google especially for translated homepages