### PR TITLE
Better support for translated pages, removed hidden pages from the sitemap

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -51,6 +51,82 @@ class SitemapPlugin extends Plugin
         }
     }
 
+    protected function pageIgnored(Page $page)
+    {
+        $header = $page->header();
+        $page_ignored = isset($header->sitemap['ignore']) ? $header->sitemap['ignore'] : false;
+        return $page_ignored;
+    }
+    
+    protected function determineLastModifiedTimestamp(Page $page)
+    {
+        // Get the initial value from the given page.
+        $retval = $page->modified();
+        
+        // Use either collection() with either the default parameters or the given modular collection names.
+        $modular_collections = [];
+        if (isset($header->sitemap['modular_collections'])) {
+            foreach ($header->sitemap['modular_collections'] as $mc_name)
+                $modular_collections[] = $page->collection($mc_name, false);
+        }
+        else {
+            $modular_collections = [$page->collection()];
+        }
+        
+        // Traverse the modular pages in the collections.
+        foreach ($modular_collections as $coll) {
+            $modular = $coll->modular();
+            foreach ($modular as $modular_page)
+                $retval = max($retval, $this->determineLastModifiedTimestamp($modular_page));
+        }
+        
+        return $retval;
+    }
+    
+    /**
+     * Determine the translated path of the given page.
+     */
+    protected function translatedPath(Page $page, string $lang)
+    {
+        $components = [];
+        while (true) {
+            // If a parent is not published, don’t include the page in the sitemap.
+            if (!($page->published() && $page->visible()))
+                return null;
+
+            $slugs = $page->translatedLanguages(true);
+            
+            if (!isset($slugs[$lang]))
+                return null;
+
+            if (!$page->home()) {
+                $slug = $slugs[$lang];
+                $components[] = $slug;
+            }
+            
+            $page = $page->parent();
+            
+            // Don’t handle the root.
+            if (is_null($page->parent()))
+                break;
+        }
+        return array_reverse($components);
+    }
+    
+    protected function translatedPage(Page $page, string $lang)
+    {
+        // I wasn’t able to find any other way to get a translated page instance
+        // than by determining the file path and instantiating a Page by myself.
+        $filename = substr($page->name(), 0, -(strlen($page->extension())));
+        $path = sprintf("%s/%s/%s.%s.md", $page->path(), $page->folder(), $filename, $lang);
+        if (file_exists($path)) {
+            $translatedPage = new Page();
+            $translatedPage->init(new \SplFileInfo($path), $lang . '.md');
+            return $translatedPage;
+        }
+        return null;
+    }
+
     /**
      * Generate data for the sitemap.
      */
@@ -67,31 +143,40 @@ class SitemapPlugin extends Plugin
 
         foreach ($routes as $route => $path) {
             $page = $pages->get($path);
-            $header = $page->header();
-            $page_ignored = isset($header->sitemap['ignore']) ? $header->sitemap['ignore'] : false;
-
-            if ($page->published() && $page->routable() && !preg_match(sprintf("@^(%s)$@i", implode('|', $ignores)), $page->route()) && !$page_ignored) {
+            if ($page->published() && $page->routable() && $page->visible() && !$this->pageIgnored($page) && !preg_match(sprintf("@^(%s)$@i", implode('|', $ignores)), $page->route())) {
                 $entry = new SitemapEntry();
                 $entry->location = $page->canonical();
-                $entry->lastmod = date('Y-m-d', $page->modified());
+                $lastmod = $this->determineLastModifiedTimestamp($page);
 
                 // optional changefreq & priority that you can set in the page header
+                $header = $page->header();
                 $entry->changefreq = (isset($header->sitemap['changefreq'])) ? $header->sitemap['changefreq'] : $this->config->get('plugins.sitemap.changefreq');
                 $entry->priority = (isset($header->sitemap['priority'])) ? $header->sitemap['priority'] : $this->config->get('plugins.sitemap.priority');
 
                 if (count($this->config->get('system.languages.supported', [])) > 0) {
-                    $entry->translated = $page->translatedLanguages(true);
-
-                    foreach($entry->translated as $lang => $page_route) {
-                        $page_route = $page->rawRoute();
-                        if ($page->home()) {
+                    $entry->translated = [];
+                    foreach ($page->translatedLanguages(true) as $lang => $page_route) {
+                        if ($page->home())
                             $page_route = '';
+                        else {
+                            $page_route = $this->translatedPath($page, $lang);
+                            if (!is_null($page_route))
+                                $page_route = '/' . join('/', $page_route);
                         }
 
-                        $entry->translated[$lang] = $page_route;
+                        if (!is_null($page_route)) {
+                            $entry->translated[$lang] = $page_route;
+
+                            // Since the last modification date is set per entry, not per URL,
+                            // consider the translations.
+                            $translated_page = $this->translatedPage($page, $lang);
+                            if (!is_null($translated_page))
+                                $lastmod = max($lastmod, $this->determineLastModifiedTimestamp($translated_page));
+                        }
                     }
                 }
 
+                $entry->lastmod = date('Y-m-d', $lastmod);
                 $this->sitemap[$route] = $entry;
             }
         }

--- a/sitemap.php
+++ b/sitemap.php
@@ -85,7 +85,7 @@ class SitemapPlugin extends Plugin
                     foreach($entry->translated as $lang => $page_route) {
                         $page_route = $page->rawRoute();
                         if ($page->home()) {
-                            $page_route = '/';
+                            $page_route = '';
                         }
 
                         $entry->translated[$lang] = $page_route;


### PR DESCRIPTION
- The plugin generated URLs for translated pages that in some cases led to Page not found errors. This happened in Grav 1.4.5 and Grav 1.6.0-rc3. I wasn’t able to identify the cause so I decided to translate all path components instead.
- Modular pages are intended to be included as part of the parent page, so they should affect its modification date.
  - By default, `page->collection()` is used to get the subpages, after which `modular()` is used to retrieve the modular pages, but the modular collections’ names may also be specified in the page’s frontmatter. I didn’t yet test this, though.
- In addition, since the sitemap format only allows for one timestamp per `url` element (including translations, to my understanding at least), the translations’ modification timestamps should affect the modification date.
- Hidden pages appeared in the sitemap, for which I didn’t see any reason, so I added a check.
- Merged Hydraner’s and CSixtyFour’s modifications.