### PR TITLE
Omit empty <lastmod>

### DIFF
--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -9,7 +9,9 @@
     <xhtml:link rel="alternate" hreflang="{{ language }}" href="{{uri.rootUrl(true)}}{{grav.language.getLanguageURLPrefix(language)}}{{ page_route }}" />
 {% endfor %}
 {% endif %}
+{% if entry.lastmod %}
     <lastmod>{{ entry.lastmod }}</lastmod>
+{% endif %}
 {% if entry.changefreq %}
     <changefreq>{{ entry.changefreq }}</changefreq>
 {% endif %}


### PR DESCRIPTION
If `lastmod` is omitted in `additions` in the YAML config it’s still included as an empty element in the XML output. Empty values for `<lastmod>` are invalid and result in errors in the Google Search Console.

The `<lastmod>` element is [optional](https://www.google.com/sitemaps/protocol.html) and should be omitted if it’s empty.