### PR TITLE
Add support for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ If you want your sitemap to only be accessible via `sitemap.xml` for example, se
 
 `Redirect 301 /sitemap /sitemap.xml`
 
-
 ## Manually add pages to the sitemap
 
 You can manually add URLs to the sitemap using the Admin settings, or by adding entries to your `sitemap.yaml` with this format:
@@ -99,3 +98,20 @@ Make sure you are subscribed to the `` event then add simply add your entry to t
 ```
 
 The use `Utils::url()` method allow us to easily create the correct full URL by passing it a route plus the optional `true` parameter.
+
+## Images
+
+You can add images to the sitemap by adding an entry in the page's Frontmatter.
+
+```
+sitemap:
+    images:
+        your_image:
+            loc: your-image.png
+            caption: A caption for the image
+            geoloc: Amsterdam, The Netherlands
+            title: The title of your image
+            license: A URL to the license of the image.
+```
+
+For more info on images in sitemaps see [Google image sitemaps](https://support.google.com/webmasters/answer/178636?hl=en).

--- a/classes/SitemapEntry.php
+++ b/classes/SitemapEntry.php
@@ -7,7 +7,7 @@ class SitemapEntry
     public $lastmod;
     public $changefreq;
     public $priority;
-    public $image;
+    public $images;
 
     /**
      * SitemapEntry constructor.
@@ -16,14 +16,14 @@ class SitemapEntry
      * @param null $lastmod
      * @param null $changefreq
      * @param null $priority
-     * @param null $image
+     * @param null $images
      */
-    public function __construct($location = null, $lastmod = null, $changefreq = null, $priority = null, $image = null)
+    public function __construct($location = null, $lastmod = null, $changefreq = null, $priority = null, $images = null)
     {
         $this->location = $location;
         $this->lastmod = $lastmod;
         $this->changefreq = $changefreq;
         $this->priority = $priority;
-        $this->image = $image;
+        $this->images = $images;
     }
 }

--- a/sitemap.php
+++ b/sitemap.php
@@ -95,9 +95,8 @@ class SitemapPlugin extends Plugin
             $page_languages = $page->translatedLanguages();
             $lang_available = (empty($page_languages) || array_key_exists($current_lang, $page_languages));
 
-
             if ($page->published() && $page->routable() && !preg_match(sprintf("@^(%s)$@i", implode('|', $ignores)), $page->route()) && !$page_ignored && $lang_available ) {
-                
+
                 $entry = new SitemapEntry();
                 $entry->location = $page->canonical();
                 $entry->lastmod = date('Y-m-d', $page->modified());
@@ -105,6 +104,17 @@ class SitemapPlugin extends Plugin
                 // optional changefreq & priority that you can set in the page header
                 $entry->changefreq = (isset($header->sitemap['changefreq'])) ? $header->sitemap['changefreq'] : $this->config->get('plugins.sitemap.changefreq');
                 $entry->priority = (isset($header->sitemap['priority'])) ? $header->sitemap['priority'] : $this->config->get('plugins.sitemap.priority');
+
+                // optional add image
+                $images = (isset($header->sitemap['images'])) ? $header->sitemap['images'] : $this->config->get('plugins.sitemap.images');
+
+                if (isset($images)) {
+                    foreach ($images as $image => $values) {
+                        $images[$image]['loc'] = $this->grav['uri']->base() . $page->media()->all()[$images[$image]['loc']]->url();
+                    }
+                }
+
+                $entry->images = $images;
 
                 if (count($this->config->get('system.languages.supported', [])) > 0) {
                     $entry->translated = $page->translatedLanguages(true);

--- a/sitemap.yaml
+++ b/sitemap.yaml
@@ -6,3 +6,4 @@ ignores:
 whitelist:
 changefreq: daily
 priority: !!float 1
+images: null

--- a/sitemap.yaml
+++ b/sitemap.yaml
@@ -6,4 +6,3 @@ ignores:
 whitelist:
 changefreq: daily
 priority: !!float 1
-images: null

--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="{{ uri.rootUrl }}/user/plugins/sitemap/sitemap.xsl"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
 {% for entry in sitemap %}
   <url>
     <loc>{{ entry.location|e }}</loc>
@@ -17,6 +19,22 @@
 {% endif %}
 {% if entry.priority %}
     <priority>{{ entry.priority|number_format(1) }}</priority>
+{% endif %}
+{% if entry.images %}
+{% for image in entry.images %}
+    <image:image>
+      <image:loc>{{ image.loc }}</image:loc>
+{% if image.caption %}
+      <image:caption>{{ image.caption }}</image:caption>
+{% endif %}
+{% if image.geoloc %}
+      <image:geo_location>{{ image.geoloc }}</image:geo_location>
+{% endif %}
+{% if image.title %}
+      <image:title>{{ image.title }}</image:title>
+{% endif %}
+    </image:image>
+{% endfor %}
 {% endif %}
   </url>
 {% endfor %}

--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -20,7 +20,6 @@
 {% if entry.priority %}
     <priority>{{ entry.priority|number_format(1) }}</priority>
 {% endif %}
-{% if entry.images %}
 {% for image in entry.images %}
     <image:image>
       <image:loc>{{ image.loc }}</image:loc>
@@ -33,9 +32,11 @@
 {% if image.title %}
       <image:title>{{ image.title }}</image:title>
 {% endif %}
+{% if image.license %}
+      <image:license>{{ image.license }}</image:license>
+{% endif %}
     </image:image>
 {% endfor %}
-{% endif %}
   </url>
 {% endfor %}
 </urlset>


### PR DESCRIPTION
Changed the placeholder for image to plural, in our case we needed multiple images on a page to show up in the sitemaps.
With some help in the grav discord I created the url for the image: <domain>/user/pages/<page>/<image-name>. This worked for our images. Not sure if this goes for everyone though.
You need to use...
```
sitemap:
    images:
        image-name:
            image-property:
```
...in the frontmatter. 
Not sure if this is clear for everybody. Should I adjust the readme to point this out?
I'm not a backender, so not really up to snuff with best practices. Please let me know if I need to adjust something.