### PR TITLE
Properly support translated entries in sitemap

### DIFF
--- a/templates/sitemap.xml.twig
+++ b/templates/sitemap.xml.twig
@@ -6,7 +6,7 @@
     <loc>{{ entry.location|e }}</loc>
 {% if entry.translated %}
 {% for language, page_route in entry.translated %}
-    <xhtml:link rel="alternate" hreflang="{{ language }}" href="{{uri.rootUrl(true)}}{{grav.language.getLanguageURLPrefix(language)}}{{ page_route }}" />
+    <xhtml:link rel="alternate" hreflang="{{ language }}" href="{{ page_route }}" />
 {% endfor %}
 {% endif %}
 {% if entry.lastmod %}


### PR DESCRIPTION
This fixes #59 by properly adding one entry for each translation of each page in sitemap, with all entries referencing all other translations of the same page.

As per https://support.google.com/webmasters/answer/189077:

> Common Mistakes
>
> Here are the most common mistakes with hreflang usage:
>
>    Missing return links: If page X links to page Y, page Y must link back to page X. If this is not the case for all pages that use hreflang annotations, those annotations may be ignored or not interpreted correctly.