### PR TITLE
add multilang setting

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -30,6 +30,18 @@ form:
       validate:
         type: bool
 
+    multilang_enabled:
+      type: toggle
+      label: PLUGIN_SITEMAP.MULTILANG_ENABLED
+      help: PLUGIN_SITEMAP.MULTILANG_ENABLED_HELP
+      highlight: 1
+      default: 1
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool
+
     ignore_external:
       type: toggle
       label: PLUGIN_SITEMAP.IGNORE_EXTERNAL

--- a/languages.yaml
+++ b/languages.yaml
@@ -30,6 +30,8 @@ en:
     IGNORE_REDIRECT_HELP: 'Ignores pages that have a custom "redirect" entry in the header'
     URLSET: 'URLSet'
     URLSET_HELP: 'The URLSet XML Namespace, don''t change this!'
+    MULTILANG_ENABLED: 'Multi-Lang Features'
+    MULTILANG_ENABLED_HELP: 'Enables support for multilanguage features'
     INCLUDE_CHANGEFREQ: 'Include Change Frequency'
     INCLUDE_PRIORITY: 'Include Priority'
     SHORT_DATE_FORMAT: 'Short Date Format'
@@ -111,6 +113,8 @@ de:
     ADDITIONS_HELP: 'Füge externe URLs zur Sitemap hinzu'
     LOCATION: 'Seiten Pfad'
     LASTMOD: 'Letzte Änderung e.g. 2017-04-06'
+    MULTILANG_ENABLED: 'Mehrsprachigkeit'
+    MULTILANG_ENABLED_HELP: 'Aktiviert Funktionen zur Mehrsprachigkeit'
 
 zh:
   PLUGIN_SITEMAP:

--- a/sitemap.php
+++ b/sitemap.php
@@ -27,6 +27,7 @@ class SitemapPlugin extends Plugin
 
     protected $multilang_skiplang_prefix = null;
     protected $multilang_include_fallbacks = false;
+    protected $multilang_enabled = true;
     protected $datetime_format = null;
     protected $include_change_freq = true;
     protected $default_change_freq = null;
@@ -102,11 +103,13 @@ class SitemapPlugin extends Plugin
         $this->sitemap = $cache->fetch($cache_id);
 
         if ($this->sitemap === false) {
+            $this->multilang_enabled = $this->config->get('plugins.sitemap.multilang_enabled');
+
             /** @var Language $language */
             $language = $this->grav['language'];
             $default_lang = $language->getDefault() ?: 'en';
             $active_lang = $language->getActive() ?? $default_lang;
-            $languages = $language->enabled() ? $language->getLanguages() : [$default_lang];
+            $languages = $this->multilang_enabled && $language->enabled() ? $language->getLanguages() : [$default_lang];
 
             $this->multilang_skiplang_prefix = $this->config->get('system.languages.include_default_lang') ?  '' : $language->getDefault();
             $this->multilang_include_fallbacks = $this->config->get('system.languages.pages_fallback_only') || !empty($this->config->get('system.languages.content_fallback'));

--- a/sitemap.yaml
+++ b/sitemap.yaml
@@ -13,3 +13,4 @@ changefreq: daily
 include_priority: true
 priority: !!float 1
 additions: []
+multilang_enabled: true


### PR DESCRIPTION
This allows for the multilang features to be optionally disabled. 

We have a use-case where we have domain1 on lang 1 and domain2 on lang2.
Their respective sitemaps shall not be interlinked.
The current version of the plugin has no way to prevent this, so this changeset would introduce such an option.

Would be nice to get this published swiftly, as this issue prevents current deployments on our system.