### PR TITLE
Use page date() not modified() for sitemap's lastmod

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -284,7 +284,7 @@ class SitemapPlugin extends Plugin
                     'lang' => $lang,
                     'translated' => in_array($lang, $page_languages),
                     'location' => $location,
-                    'lastmod' => date($this->datetime_format, $page->modified()),
+                    'lastmod' => date($this->datetime_format, $page->date()),
                 ];
 
                 if ($this->include_change_freq) {


### PR DESCRIPTION
I think the `$page->date()` method makes more sense and falls back to modified when not set.