### PR TITLE
Remove type hints for PHP 7.3 compatibility

### DIFF
--- a/classes/SitemapEntry.php
+++ b/classes/SitemapEntry.php
@@ -14,10 +14,10 @@ class SitemapEntry
     public $images;
     public $hreflangs = [];
 
-    public int $timestamp;
-    public string $rawroute;
-    public string $longdate;
-    public string $shortdate;
+    public $timestamp;
+    public $rawroute;
+    public $longdate;
+    public $shortdate;
 
     /**
      * SitemapEntry constructor.


### PR DESCRIPTION
The type hints that I removed require PHP 7.4+ but Grav only requires 7.3.6. By removing these type hints, we make sure the plugin also works for folk running Grav with PHP 7.3.

Fixes #109.