### PR TITLE
Add option to set a custom `lastmod` date

### DIFF
--- a/blueprints/sitemap.yaml
+++ b/blueprints/sitemap.yaml
@@ -25,6 +25,11 @@ form:
                     type: bool
                     required: false
 
+                header.sitemap.lastmod:
+                  type: datetime
+                  label: PLUGIN_SITEMAP.HEADER_LASTMOD
+                  default: ''
+
                 header.sitemap.changefreq:
                   type: select
                   label: PLUGIN_SITEMAP.HEADER_CHANGEFREQ

--- a/blueprints/sitemap.yaml
+++ b/blueprints/sitemap.yaml
@@ -27,7 +27,6 @@ form:
 
                 header.sitemap.lastmod:
                   type: datetime
-                  toggleable: true
                   label: PLUGIN_SITEMAP.HEADER_LASTMOD
                   default: ''
 

--- a/blueprints/sitemap.yaml
+++ b/blueprints/sitemap.yaml
@@ -27,6 +27,7 @@ form:
 
                 header.sitemap.lastmod:
                   type: datetime
+                  toggleable: true
                   label: PLUGIN_SITEMAP.HEADER_LASTMOD
                   default: ''
 

--- a/languages.yaml
+++ b/languages.yaml
@@ -2,6 +2,7 @@ en:
   PLUGIN_SITEMAP:
     SITEMAP: 'Sitemap'
     HEADER_IGNORE: 'Sitemap ignore page'
+    HEADER_LASTMOD: 'Sitemap Last Modified'
     HEADER_CHANGEFREQ: 'Sitemap Change Frequency'
     HEADER_PRIORITY: 'Sitemap priority'
     CHANGEFREQ: 'Global - Sitemap Change Frequency'

--- a/sitemap.php
+++ b/sitemap.php
@@ -310,7 +310,7 @@ class SitemapPlugin extends Plugin
                 $include_lang = $this->multilang_skiplang_prefix !== $lang;
                 $location = $page->canonical($include_lang);
                 $url = $page->url(false, $include_lang);
-				$lastmod = isset($header->sitemap['lastmod']) ? strtotime($header->sitemap['lastmod']) : $page->modified();
+                $lastmod = !empty($header->sitemap['lastmod']) ? strtotime($header->sitemap['lastmod']) : $page->modified();
 
                 $lang_route = [
                     'title' => $page->title(),

--- a/sitemap.php
+++ b/sitemap.php
@@ -310,11 +310,7 @@ class SitemapPlugin extends Plugin
                 $include_lang = $this->multilang_skiplang_prefix !== $lang;
                 $location = $page->canonical($include_lang);
                 $url = $page->url(false, $include_lang);
-				if (isset($header->sitemap['lastmod'])){
-					$lastmod = strtotime($header->sitemap['lastmod']);
-				} else {
-					$lastmod = $page->modified();
-				}
+				$lastmod = isset($header->sitemap['lastmod']) ? strtotime($header->sitemap['lastmod']) : $page->modified();
 
                 $lang_route = [
                     'title' => $page->title(),

--- a/sitemap.php
+++ b/sitemap.php
@@ -310,6 +310,11 @@ class SitemapPlugin extends Plugin
                 $include_lang = $this->multilang_skiplang_prefix !== $lang;
                 $location = $page->canonical($include_lang);
                 $url = $page->url(false, $include_lang);
+				if (isset($header->sitemap['lastmod'])){
+					$lastmod = strtotime($header->sitemap['lastmod']);
+				} else {
+					$lastmod = $page->modified();
+				}
 
                 $lang_route = [
                     'title' => $page->title(),
@@ -318,7 +323,7 @@ class SitemapPlugin extends Plugin
                     'lang' => $lang,
                     'translated' => in_array($lang, $page_languages),
                     'location' => $location,
-                    'lastmod' => date($this->datetime_format, $page->modified()),
+                    'lastmod' => date($this->datetime_format, $lastmod),
                     'longdate' => date('Y-m-d\TH:i:sP', $page->date()),
                     'shortdate' => date('Y-m-d', $page->date()),
                     'timestamp' => $page->date(),


### PR DESCRIPTION
This PR adds an option to all pages to manually set a `lastmod` date.

If `sitemap.lastmod` is not set in a pages header, it takes the legacy `$page->modified()`. With this, the `lastmod` option can be overridden, for example if:

- a page file is edited, but only something minor like frontmatter or formatting
- a site is migrated from another CMS, the file timestamps are recent but the content has not changed
- data displayed by the page is changed but the page .md file has not been touched. For example, the page contains content sourced from a datasource, a modular child, or displays a gallery which changed.

---

This is an enhanced version of @hughbris #98

_closes #98, #99_