### PR TITLE
Fixes HTML pattern character class escaping for v flag compatibility

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -36,7 +36,7 @@ form:
       label: PLUGIN_SITEMAP.ROUTE
       placeholder: /sitemap
       validate:
-        pattern: "/([a-z-_]+/?)+"
+        pattern: '/([a-z\-_]+/?)+'
 
     multilang_enabled:
       type: toggle


### PR DESCRIPTION
## The problem

On the plugin page of the Grav plugin sitemap in the browser console the following error appears:

Firefox:
```js
Unable to check <input pattern=‘/([a-z-_]+/?)+’> because ‘//([a-z-_]+/?)+/v’ is not a valid regexp: character class escape cannot be used in class range in regular expression
```
Chromium:
```js
Pattern attribute value /([a-z-_]+/?)+ is not a valid regular expression: Uncaught SyntaxError: Failed to execute 'checkValidity' on 'HTMLInputElement': Invalid regular expression: //([a-z-_]+/?)+/v: Invalid character class
```
This pattern belongs to the input for the sitemap route in the file [blueprints.yaml](https://github.com/getgrav/grav-plugin-sitemap/blob/develop/blueprints.yaml#L39)

## Testing environment

  - Browser: Firefox 147/149, Chromium 147
  - Grav-plugin-sitemap version: 5.1.0
  - Grav version: 1.7.49.5 and 1.8

## The reason for the error

According to the[ MDN documentation on the HTML pattern attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern) (updated January 25, 2026):

> "The pattern's regular expression is compiled with the **`'v'` flag**. This makes the regular expression unicode-aware, and also changes how character classes are interpreted. This allows character class set intersection and subtraction operations, and in addition to `]` and `\`, the following characters must be escaped using a `\` backslash ***if they represent literal characters***: `(`, `)`, `[`, `{`, `}`, `/`, `-`, `|`."

The documentation also notes: "Before mid-2023, the `'u'` flag was specified instead; if you're updating older code, read the `unicodeSets` reference."


***Key Differences***

| Aspect | `u` flag | `v` flag |
|--------|----------|---------|
| **Hyphen in `[a-z-]`** | Works without escaping | Must escape: `[a-z\-]` |
| **Current HTML standard** | Deprecated (pre-mid-2023) | Current standard (mid-2023 onwards) |
| **Character class restrictions** | Fewer special chars need escaping | More characters must be escaped: `(`, `)`, `[`, `{`, `}`, `/`, `-`, `\|` |


## Changes in this pull request

The HTML pattern attribute for the `route` input was changed in the `blueprints.yaml` file:

```diff
-"/([a-z-_]+/?)+"
+'/([a-z\-_]+/?)+'
```

The hyphen character is now properly escaped within the character classes.
The double quotes are replaced with single quotes because all characters inside single quotes are treated literally, and no escaping is performed through the YAML parser.

With double quotes and a single escaped hyphen character the Yaml Linter shows:

```bash
php bin/grav yamllinter -f user/plugins/

Yaml Linter
===========

user/plugins/
-------------
                                                                                                        
 [ERROR] YAML Linting issues found...
                                                                                                                        
user/plugins/sitemap/blueprints.yaml - Found unknown escape character "\-" at line 39 (near "pattern: "/([a-z\-_]+/?)+"").
```

If double quotes should be used the hyphen character has to be double escaped. 

## Tests for the regular expression

***In the browser console:***

```js
new RegExp('^(?:' + String.raw`/([a-z-_]+/?)+` + ')$', 'v').test('/sitemap-on_e'); // -> throws:
// Uncaught SyntaxError: character class escape cannot be used in class range in regular expression

new RegExp('^(?:' + String.raw`/([a-z\-_]+/?)+` + ')$', 'v').test('/sitemap-on_e'); // -> true
new RegExp('^(?:' + String.raw`/([a-z\-_]+/?)+` + ')$', 'u').test('/sitemap-on_e'); // -> true
```
